### PR TITLE
refactor chat server join room method

### DIFF
--- a/actix-api/src/actors/chat_server.rs
+++ b/actix-api/src/actors/chat_server.rs
@@ -122,7 +122,13 @@ impl Handler<JoinRoom> for ChatServer {
             if msg.subject == format!("room.{}.{}", room_clone, session_clone) {
                 return Ok(());
             }
-            let msg = MediaPacket::parse_from_bytes(&msg.data).unwrap();
+            let msg = match MediaPacket::parse_from_bytes(&msg.data) {
+                Ok(msg) => msg,
+                Err(e) => {
+                    error!("error parsing message: {}", e);
+                    return Ok(());
+                }
+            };
             let msg = Message {
                 nickname: Arc::new(Some(msg.email.clone())),
                 msg: Arc::new(msg),

--- a/actix-api/src/actors/chat_server.rs
+++ b/actix-api/src/actors/chat_server.rs
@@ -173,7 +173,7 @@ fn build_handler(
             Ok(media_packet) => media_packet,
             Err(e) => {
                 error!("error parsing message: {}", e);
-                return Ok(());
+                return Err(std::io::Error::new(std::io::ErrorKind::Other, e));
             }
         };
 

--- a/actix-api/src/actors/chat_server.rs
+++ b/actix-api/src/actors/chat_server.rs
@@ -111,7 +111,7 @@ impl Handler<JoinRoom> for ChatServer {
             None => {
                 let err = format!("session {} is not connected", session);
                 error!("{}", err);
-                return MessageResult(Err(err.into()));
+                return MessageResult(Err(err));
             }
         };
 


### PR DESCRIPTION
Prior to this change, if the server received a message that was not a MediaPacket protobuf message, it would crash while attempting to deserialize it.

I also took the time to refactor the handle a bit into multiple methods